### PR TITLE
Update Swagger to OpenAPI 3.0 for Enabling JWT

### DIFF
--- a/docs/swagger/activity.yaml
+++ b/docs/swagger/activity.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+openapi: '3.0.1'
 info:
   description: |
     Welcome to the HumHub activity module API reference.

--- a/docs/swagger/auth.yaml
+++ b/docs/swagger/auth.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+openapi: '3.0.1'
 info:
   description: |
     Welcome to the HumHub auth module API reference.

--- a/docs/swagger/calendar.yaml
+++ b/docs/swagger/calendar.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+openapi: '3.0.1'
 info:
   description: |
     Welcome to the HumHub calendar module API reference.

--- a/docs/swagger/cfiles.yaml
+++ b/docs/swagger/cfiles.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+openapi: '3.0.1'
 info:
   description: |
     Welcome to the HumHub cFiles module API reference.

--- a/docs/swagger/comment.yaml
+++ b/docs/swagger/comment.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+openapi: '3.0.1'
 info:
   description: |
     Welcome to the HumHub comment module API reference.

--- a/docs/swagger/common.yaml
+++ b/docs/swagger/common.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+openapi: '3.0.1'
 
 securityDefinitions:
   Bearer:

--- a/docs/swagger/content.yaml
+++ b/docs/swagger/content.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+openapi: '3.0.1'
 info:
   description: |
     Welcome to the HumHub content module API reference.

--- a/docs/swagger/file.yaml
+++ b/docs/swagger/file.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+openapi: '3.0.1'
 info:
   description: |
     Welcome to the HumHub file module API reference.

--- a/docs/swagger/like.yaml
+++ b/docs/swagger/like.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+openapi: '3.0.1'
 info:
   description: |
     Welcome to the HumHub like module API reference.

--- a/docs/swagger/notification.yaml
+++ b/docs/swagger/notification.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+openapi: '3.0.1'
 info:
   description: |
     Welcome to the HumHub notification module API reference.

--- a/docs/swagger/post.yaml
+++ b/docs/swagger/post.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+openapi: '3.0.1'
 info:
   description: |
     Welcome to the HumHub post module API reference.

--- a/docs/swagger/space.yaml
+++ b/docs/swagger/space.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+openapi: '3.0.1'
 info:
   description: |
     Welcome to the HumHub space module API reference.

--- a/docs/swagger/task.yaml
+++ b/docs/swagger/task.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+openapi: '3.0.1'
 info:
   description: |
     Welcome to the HumHub tasks module API reference.

--- a/docs/swagger/topic.yaml
+++ b/docs/swagger/topic.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+openapi: '3.0.1'
 info:
   description: |
     Welcome to the HumHub topic module API reference.

--- a/docs/swagger/user.yaml
+++ b/docs/swagger/user.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+openapi: '3.0.1'
 info:
   description: |
     Welcome to the HumHub user module API reference.

--- a/docs/swagger/wiki.yaml
+++ b/docs/swagger/wiki.yaml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+openapi: '3.0.1'
 info:
   description: |
     Welcome to the HumHub wiki module API reference.


### PR DESCRIPTION
It is not possible to generate clients from swagger 2.0 when [common.yaml](https://github.com/humhub/humhub-modules-rest/blob/master/docs/swagger/common.yaml#L5) contains `type: JWT` which is an OpenAPI 3.0 feature. See: https://github.com/swagger-api/swagger-ui/issues/3860#issuecomment-341586595
