### PR TITLE
Don’t require target folder id to create root automatically

### DIFF
--- a/controllers/cfiles/FolderController.php
+++ b/controllers/cfiles/FolderController.php
@@ -48,11 +48,15 @@ class FolderController extends BaseContentController
         $isPublicDirectory = isset($params['Folder']['visibility']) && $params['Folder']['visibility'] === Content::VISIBILITY_PUBLIC;
 
         if (empty($params['target_id'])) {
-            return $this->returnError(400, 'Target folder id is required!');
+            if (!($targetDir = Folder::getRoot($container)) &&
+                !($targetDir = Folder::initRoot($container))) {
+                return $this->returnError(400, 'Target folder id is required!');
+            }
+        } else {
+            $targetDir = Folder::findOne(['id' => $params['target_id']]);
         }
 
-        $targetDir = Folder::findOne(['id' => $params['target_id']]);
-        if ($targetDir === null) {
+        if (empty($targetDir)) {
             return $this->returnError(404, 'cFiles folder not found!');
         }
         if (!$container->can(ManageFiles::class)) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 0.2.1  (Unreleased)
 -------------------------
-- Enh #45: Don’t require target folder id to create root automatically
+- Enh #45: Files Endpoint - Don’t require target folder id to create root automatically
 
 
 0.2.0-beta.1  (November 23, 2020)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.2.1  (Unreleased)
+-------------------------
+- Enh #45: Don’t require target folder id to create root automatically
+
+
 0.2.0-beta.1  (November 23, 2020)
 ---------------------------------
 - Enh: New Endpoints for Mail module

--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
     "keywords": [
         "api", "rest"
     ],
-    "version": "0.2.0-beta.1",
+    "version": "0.2.1",
     "humhub": {
         "minVersion": "1.7"
     },


### PR DESCRIPTION
Issue: https://github.com/humhub/humhub-modules-rest/issues/45#issuecomment-767485707